### PR TITLE
Add RecordSet to create DNS records for elastic IPs

### DIFF
--- a/aws/aws_suite_test.go
+++ b/aws/aws_suite_test.go
@@ -1,0 +1,13 @@
+package aws_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestAws(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Aws Suite")
+}

--- a/aws/cloud_former.go
+++ b/aws/cloud_former.go
@@ -88,3 +88,14 @@ func (cloudFormer *AWSCloudFormer) LoadBalancer(name string) cloudformer.LoadBal
 		resources: cloudFormer.resources,
 	}
 }
+
+func (cloudFormer *AWSCloudFormer) RecordSet(name string) cloudformer.RecordSet {
+	recordSet := RecordSet{
+		name:  name,
+		model: &models.RecordSet{},
+	}
+
+	cloudFormer.resources[name+"RecordSet"] = recordSet.model
+
+	return recordSet
+}

--- a/aws/cloud_former_test.go
+++ b/aws/cloud_former_test.go
@@ -1,0 +1,51 @@
+package aws_test
+
+import (
+	"encoding/json"
+
+	"github.com/vito/cloudformer/aws"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AWSCloudFormer", func() {
+	It("creates a DNS A record for an elastic IP", func() {
+		f := aws.New("elastic IP with A record")
+
+		eip := f.ElasticIP("bosh")
+
+		recordSet := f.RecordSet("bosh")
+		recordSet.HostedZoneName("test.com.")
+		recordSet.Name("bosh.test.com")
+		recordSet.TTL(300)
+		recordSet.PointTo(eip)
+
+		Expect(json.Marshal(f.Template)).To(MatchJSON(`
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "elastic IP with A record",
+  "Mappings": {},
+  "Resources": {
+    "boshEIP": {
+      "Type": "AWS::EC2::EIP"
+    },
+    "boshRecordSet": {
+      "Properties": {
+        "HostedZoneName": "test.com.",
+        "Name": "bosh.test.com",
+        "ResourceRecords": [
+          {
+            "Ref": "boshEIP"
+          }
+        ],
+        "TTL": 300,
+        "Type": "A"
+      },
+      "Type": "AWS::Route53::RecordSet"
+    }
+  }
+}
+		`))
+	})
+})

--- a/aws/load_balancer.go
+++ b/aws/load_balancer.go
@@ -80,7 +80,7 @@ func (balancer LoadBalancer) RecordSet(name, zone string) {
 			RecordSets: []models.RecordSet{
 				{
 					Name: name + "." + zone + ".",
-					Type: "A",
+					RecordSetType: "A",
 					AliasTarget: models.RecordSetAliasTarget{
 						HostedZoneId: models.Hash{
 							"Fn::GetAtt": []string{

--- a/aws/models/models.go
+++ b/aws/models/models.go
@@ -333,9 +333,20 @@ func (RecordSetGroup) DependsOn() string {
 }
 
 type RecordSet struct {
-	Name        interface{} `json:"Name,omitempty"`
-	Type        interface{} `json:"Type,omitempty"`
-	AliasTarget interface{} `json:"AliasTarget,omitempty"`
+	Name            interface{} `json:"Name,omitempty"`
+	RecordSetType   interface{} `json:"Type,omitempty"`
+	AliasTarget     interface{} `json:"AliasTarget,omitempty"`
+	TTL             interface{} `json:"TTL,omitempty"`
+	ResourceRecords interface{} `json:"ResourceRecords,omitempty"`
+	HostedZoneName  interface{} `json:"HostedZoneName,omitempty"`
+}
+
+func (RecordSet) Type() string {
+	return "AWS::Route53::RecordSet"
+}
+
+func (RecordSet) DependsOn() string {
+	return ""
 }
 
 type RecordSetAliasTarget struct {

--- a/aws/record_set.go
+++ b/aws/record_set.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"github.com/vito/cloudformer"
+	"github.com/vito/cloudformer/aws/models"
+)
+
+type RecordSet struct {
+	name  string
+	model *models.RecordSet
+}
+
+func (recordSet RecordSet) HostedZoneName(hostedZoneName string) {
+	recordSet.model.HostedZoneName = hostedZoneName
+}
+
+func (recordSet RecordSet) Name(name string) {
+	recordSet.model.Name = name
+}
+
+func (recordSet RecordSet) PointTo(elasticIP cloudformer.ElasticIP) {
+	recordSet.model.RecordSetType = "A"
+	recordSet.model.ResourceRecords = []models.Hash{models.Ref(elasticIP.(ElasticIP).name + "EIP")}
+}
+
+func (recordSet RecordSet) TTL(ttl int) {
+	recordSet.model.TTL = ttl
+}

--- a/cloud_former.go
+++ b/cloud_former.go
@@ -11,6 +11,7 @@ type CloudFormer interface {
 	ElasticIP(name string) ElasticIP
 	LoadBalancer(name string) LoadBalancer
 	Bucket(name string) Bucket
+	RecordSet(name string) RecordSet
 }
 
 type InternetGateway interface{}
@@ -89,4 +90,11 @@ const UDP = ProtocolType("udp")
 
 type Bucket interface {
 	Name(string)
+}
+
+type RecordSet interface {
+	HostedZoneName(hostedZoneName string)
+	Name(name string)
+	PointTo(ElasticIP)
+	TTL(ttl int)
 }


### PR DESCRIPTION
RecordSets can currently only create A records to elastic IPs.
This is preliminary work for a future boosh pull request to
create the DNS record for bosh.
